### PR TITLE
Allow setCacheFile method on router, Alias Slim's Router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "~5.5|~7.0",
         "php-di/php-di": "^5.2.0",
         "php-di/invoker": "^1.2.0",
-        "slim/slim": "^3.2.1"
+        "slim/slim": "^3.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"

--- a/src/config.php
+++ b/src/config.php
@@ -35,7 +35,9 @@ return [
     ],
 
     // Default Slim services
-    'router' => DI\object(Slim\Router::class),
+    'router' => DI\object(Slim\Router::class)
+        ->method('setCacheFile', DI\get('settings.routerCacheFile')),
+    Slim\Router::class => DI\get('router'),
     'errorHandler' => DI\object(Slim\Handlers\Error::class)
         ->constructor(DI\get('settings.displayErrorDetails')),
     'phpErrorHandler' => DI\object(Slim\Handlers\PhpError::class)


### PR DESCRIPTION
- Pass any settings for routerCacheFile to the setCacheFile method to enable FastRoute’s cache.
- Add an alias Slim\Router => 'router' so you can type hint the Router in a controller.
