### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "slim/slim": "^3.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8.36"
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -4,9 +4,10 @@ namespace DI\Bridge\Slim\Test;
 
 use DI\Bridge\Slim\App;
 use DI\Bridge\Slim\Test\Mock\RequestFactory;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Response;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     /**
      * @test

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -3,8 +3,9 @@
 namespace DI\Bridge\Slim\Test;
 
 use DI\Bridge\Slim\App;
+use PHPUnit\Framework\TestCase;
 
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class ContainerTest extends TestCase
 {
     /**
      * Slim expects some container entries to exist. To check that, we get all entries from the

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -4,11 +4,12 @@ namespace DI\Bridge\Slim\Test;
 
 use DI\Bridge\Slim\App;
 use DI\Bridge\Slim\Test\Mock\RequestFactory;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Response;
 
-class MiddlewareTest extends \PHPUnit_Framework_TestCase
+class MiddlewareTest extends TestCase
 {
     /**
      * @test

--- a/tests/RoutingTest.php
+++ b/tests/RoutingTest.php
@@ -5,11 +5,12 @@ namespace DI\Bridge\Slim\Test;
 use DI\Bridge\Slim\App;
 use DI\Bridge\Slim\Test\Fixture\UserController;
 use DI\Bridge\Slim\Test\Mock\RequestFactory;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Response;
 
-class RoutingTest extends \PHPUnit_Framework_TestCase
+class RoutingTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.