### PR TITLE
Fix #25 Inject request attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ By default, Slim controllers have a strict signature: `$request, $response, $arg
 
 Controller parameters can be any of these things:
 
-- request or response injection (parameters must be named `$request` or `$response`)
-- request attribute injection
-- service injection (by type-hint)
+- the request or response (parameters must be named `$request` or `$response`)
+- route placeholders
+- request attributes
+- services (injected by type-hint)
 
 You can mix all these types of parameters together too. They will be matched by priority in the order of the list above.
 
@@ -72,7 +73,7 @@ $app->get('/', function (ResponseInterface $response, ServerRequestInterface $re
 
 As you can see, the order of the parameters doesn't matter. That allows to skip injecting the `$request` if it's not needed for example.
 
-#### Request attribute injection
+#### Route placeholder injection
 
 ```php
 $app->get('/hello/{name}', function ($name, ResponseInterface $response) {
@@ -82,6 +83,22 @@ $app->get('/hello/{name}', function ($name, ResponseInterface $response) {
 ```
 
 As you can see above, the route's URL contains a `name` placeholder. By simply adding a parameter **with the same name** to the controller, PHP-DI will directly inject it.
+
+#### Request attribute injection
+
+```php
+$app->add(function ($request, $response, $next) {
+    $request = $request->withAttribute('name', 'Bob');
+    return $next($request, $response);
+});
+
+$app->get('/', function ($name, ResponseInterface $response) {
+    $response->getBody()->write('Hello ' . $name);
+    return $response;
+});
+```
+
+As you can see above, a middleware sets a `name` attribute. By simply adding a parameter **with the same name** to the controller, PHP-DI will directly inject it.
 
 #### Service injection
 

--- a/src/ControllerInvoker.php
+++ b/src/ControllerInvoker.php
@@ -44,6 +44,9 @@ class ControllerInvoker implements InvocationStrategyInterface
         // Inject the route arguments by name
         $parameters += $routeArguments;
 
+        // Inject the attributes defined on the request
+        $parameters += $request->getAttributes();
+
         return $this->invoker->call($callable, $parameters);
     }
 }


### PR DESCRIPTION
Currently route placeholders are injected in controllers. This was wrongly called "request attribute" in the documentation.

This adds the ability to inject (actual) request attributes in controller parameters too.

Route placeholders take priority over request attributes.

Example:

```php
$app->add(function ($request, $response, $next) {
    $request = $request->withAttribute('name', 'Bob');
    return $next($request, $response);
});

$app->get('/', function ($name, ResponseInterface $response) {
    $response->getBody()->write('Hello ' . $name);
    return $response;
});
```

Will show `Hello Bob`.