### PR TITLE
Revert PR #31 - Output buffering in error handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "~5.5|~7.0",
         "php-di/php-di": "^5.2.0",
         "php-di/invoker": "^1.2.0",
-        "slim/slim": "^3.4.0"
+        "slim/slim": "^3.9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.36"

--- a/src/config.php
+++ b/src/config.php
@@ -39,9 +39,9 @@ return [
         ->method('setCacheFile', DI\get('settings.routerCacheFile')),
     Slim\Router::class => DI\get('router'),
     'errorHandler' => DI\object(Slim\Handlers\Error::class)
-        ->constructor(DI\get('settings.displayErrorDetails'), DI\get('settings.outputBuffering')),
+        ->constructor(DI\get('settings.displayErrorDetails')),
     'phpErrorHandler' => DI\object(Slim\Handlers\PhpError::class)
-        ->constructor(DI\get('settings.displayErrorDetails'), DI\get('settings.outputBuffering')),
+        ->constructor(DI\get('settings.displayErrorDetails')),
     'notFoundHandler' => DI\object(Slim\Handlers\NotFound::class),
     'notAllowedHandler' => DI\object(Slim\Handlers\NotAllowed::class),
     'environment' => function () {


### PR DESCRIPTION
As of Slim 3.9 the output buffering was moved from the error handler (as an argument) and into the main Slim app.

**IMPORTANT NOTE**: Slim-Bridge `composer.json` indicated a dependency on Slim ^3.4.0  ==> This PR changes the dependency to ^3.9.0

The PR #31 added the output buffering argument in slim-bridge. This PR reverts PR #31 and modifies the unit tests to validate the change to error handling.

Closes #33