### PR TITLE
Set container on router

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -36,6 +36,7 @@ return [
 
     // Default Slim services
     'router' => DI\object(Slim\Router::class)
+        ->method('setContainer', DI\get(Container::class))
         ->method('setCacheFile', DI\get('settings.routerCacheFile')),
     Slim\Router::class => DI\get('router'),
     'errorHandler' => DI\object(Slim\Handlers\Error::class)


### PR DESCRIPTION
Dependency injection into controllers doesn't seem to work correctly without doing this.

It is done by Slim's [DefaultServicesProvider](https://github.com/slimphp/Slim/blob/52bab5fe84391fa174209852f3221ffe2bf261fc/Slim/DefaultServicesProvider.php#L97) normally, so we should be doing it too.