### PR TITLE
New Request and Response aliases

### DIFF
--- a/src/ControllerInvoker.php
+++ b/src/ControllerInvoker.php
@@ -39,6 +39,8 @@ class ControllerInvoker implements InvocationStrategyInterface
         $parameters = [
             'request'  => $request,
             'response' => $response,
+            'req'      => $request,
+            'res'      => $response,
         ];
 
         // Inject the route arguments by name

--- a/src/config.php
+++ b/src/config.php
@@ -54,12 +54,14 @@ return [
     'request' => function (ContainerInterface $c) {
         return Request::createFromEnvironment($c->get('environment'));
     },
+    'req' => 'request',
     'response' => function (ContainerInterface $c) {
         $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
         $response = new Response(200, $headers);
         return $response->withProtocolVersion($c->get('settings')['httpVersion']);
     },
-    'foundHandler' => create(ControllerInvoker::class)
+    'res' => 'response',
+    'foundHandler' => c
         ->constructor(get('foundHandler.invoker')),
     'foundHandler.invoker' => function (ContainerInterface $c) {
         $resolvers = [

--- a/src/config.php
+++ b/src/config.php
@@ -61,7 +61,7 @@ return [
         return $response->withProtocolVersion($c->get('settings')['httpVersion']);
     },
     'res' => 'response',
-    'foundHandler' => c
+    'foundHandler' => create(ControllerInvoker::class)
         ->constructor(get('foundHandler.invoker')),
     'foundHandler.invoker' => function (ContainerInterface $c) {
         $resolvers = [

--- a/src/config.php
+++ b/src/config.php
@@ -15,6 +15,8 @@ use Psr\Container\ContainerInterface;
 use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 return [
 
@@ -54,13 +56,17 @@ return [
     'request' => function (ContainerInterface $c) {
         return Request::createFromEnvironment($c->get('environment'));
     },
-    'req' => 'request',
+    'req' => DI\get('request'),
+    ServerRequestInterface::class => DI\get('request'),
+    Request::class => DI\get('request'),
     'response' => function (ContainerInterface $c) {
         $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
         $response = new Response(200, $headers);
         return $response->withProtocolVersion($c->get('settings')['httpVersion']);
     },
-    'res' => 'response',
+    'res' => DI\get('response'),
+    ResponseInterface::class => DI\get('response'),
+    Response::class => DI\get('response'),
     'foundHandler' => create(ControllerInvoker::class)
         ->constructor(get('foundHandler.invoker')),
     'foundHandler.invoker' => function (ContainerInterface $c) {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -4,6 +4,10 @@ namespace DI\Bridge\Slim\Test;
 
 use DI\Bridge\Slim\App;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Http\Request;
+use Slim\Http\Response;
 
 class ContainerTest extends TestCase
 {
@@ -55,5 +59,63 @@ class ContainerTest extends TestCase
             // Has the same default value
             $this->assertEquals($value, $actualOptions[$name]);
         }
+    }
+
+    /**
+     * Makes sure Request definitions can be injected.
+     *
+     * @test
+     */
+    public function provides_request_objects()
+    {
+        $slimPhpDi = new App;
+
+        /** @var \DI\Container $phpdiContainer */
+        $phpdiContainer = $slimPhpDi->getContainer();
+
+        $request = $phpdiContainer->get('request');
+        $this->assertNotNull($request);
+        $this->assertInstanceOf(ServerRequestInterface::class, $request);
+        
+        $res = $phpdiContainer->get('req');
+        $this->assertNotNull($res);
+        $this->assertInstanceOf(ServerRequestInterface::class, $res);
+        
+        $request_interface = $phpdiContainer->get(ServerRequestInterface::class);
+        $this->assertNotNull($request_interface);
+        $this->assertInstanceOf(ServerRequestInterface::class, $request_interface);
+
+        $request_slim = $phpdiContainer->get(Request::class);
+        $this->assertNotNull($request_slim);
+        $this->assertInstanceOf(ServerRequestInterface::class, $request_slim);
+    }
+
+    /**
+     * Makes sure Response definitions can be injected.
+     *
+     * @test
+     */
+    public function provides_response_objects()
+    {
+        $slimPhpDi = new App;
+
+        /** @var \DI\Container $phpdiContainer */
+        $phpdiContainer = $slimPhpDi->getContainer();
+
+        $response = $phpdiContainer->get('response');
+        $this->assertNotNull($response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        
+        $res = $phpdiContainer->get('res');
+        $this->assertNotNull($res);
+        $this->assertInstanceOf(ResponseInterface::class, $res);
+        
+        $response_interface = $phpdiContainer->get(ResponseInterface::class);
+        $this->assertNotNull($response_interface);
+        $this->assertInstanceOf(ResponseInterface::class, $response_interface);
+
+        $response_slim = $phpdiContainer->get(Response::class);
+        $this->assertNotNull($response_slim);
+        $this->assertInstanceOf(ResponseInterface::class, $response_slim);
     }
 }


### PR DESCRIPTION
#### Why? 

Because this way allows users to use different parameter names and aligns the container with the Slim documentation examples, which uses injection trough bindings that differ from `$request` and `$response`.

#### Tests

There are 2 new tests with 20 assertions (in 3 tests).