### PR TITLE
Updated request attribute injection for Slim v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ As you can see above, the route's URL contains a `name` placeholder. By simply a
 #### Request attribute injection
 
 ```php
-$app->add(function ($request, $response, $next) {
+$app->add(function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
     $request = $request->withAttribute('name', 'Bob');
-    return $next($request, $response);
+    $response = $handler->handle($request);
+    return $response;
 });
 
 $app->get('/', function ($name, ResponseInterface $response) {


### PR DESCRIPTION
The example for "Request attribute injection" was not compatible for Slim v4, I have updated it.
This assumes there is a `use Psr\Http\Server\RequestHandlerInterface;`.

This addresses Issue #59.