### PR TITLE
feat: change private createControllerInvoker to protected

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -39,7 +39,7 @@ class Bridge
         return $app;
     }
 
-    private static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
+    protected static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
     {
         $resolvers = [
             // Inject parameters by name first


### PR DESCRIPTION
I need to overwrite the Bridge::create function because I need a custom Slim/AppFactory / Slim/App. With help of the protected createControllerInvoker instead of private I do not need to rewirte that code.

I hope it is clear and possible to use protected instead of private. 

Thanks in advanced.