### PR TITLE
Upgraded CallableResolver to Advanced interface

### DIFF
--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -60,9 +60,9 @@ class CallableResolver implements AdvancedCallableResolverInterface
 
     private function resolvePossibleSignature($toResolve, string $method, string $typeName): callable
     {
-        $toResolve = $this->translateNotation($toResolve);
-
         if (is_string($toResolve)) {
+            $toResolve = $this->translateNotation($toResolve);
+
             try {
                 $callable = $this->callableResolver->resolve([$toResolve, $method]);
 

--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -27,9 +27,7 @@ class CallableResolver implements AdvancedCallableResolverInterface
      */
     public function resolve($toResolve): callable
     {
-        $toResolve = $this->translateNotation($toResolve);
-
-        return $this->callableResolver->resolve($toResolve);
+        return $this->callableResolver->resolve($this->translateNotation($toResolve));
     }
 
     /**
@@ -37,8 +35,6 @@ class CallableResolver implements AdvancedCallableResolverInterface
      */
     public function resolveRoute($toResolve): callable
     {
-        $toResolve = $this->translateNotation($toResolve);
-
         return $this->resolvePossibleSignature($toResolve, 'handle', RequestHandlerInterface::class);
     }
 
@@ -47,8 +43,6 @@ class CallableResolver implements AdvancedCallableResolverInterface
      */
     public function resolveMiddleware($toResolve): callable
     {
-        $toResolve = $this->translateNotation($toResolve);
-
         return $this->resolvePossibleSignature($toResolve, 'process', MiddlewareInterface::class);
     }
 
@@ -66,9 +60,11 @@ class CallableResolver implements AdvancedCallableResolverInterface
 
     private function resolvePossibleSignature($toResolve, string $method, string $typeName): callable
     {
+        $toResolve = $this->translateNotation($toResolve);
+
         if (is_string($toResolve)) {
             try {
-                $callable = $this->resolve([$toResolve, $method]);
+                $callable = $this->callableResolver->resolve([$toResolve, $method]);
 
                 if (is_array($callable) && $callable[0] instanceof $typeName) {
                     return $callable;
@@ -78,6 +74,6 @@ class CallableResolver implements AdvancedCallableResolverInterface
             }
         }
 
-        return $this->resolve($toResolve);
+        return $this->callableResolver->resolve($toResolve);
     }
 }

--- a/src/CallableResolver.php
+++ b/src/CallableResolver.php
@@ -2,12 +2,15 @@
 
 namespace DI\Bridge\Slim;
 
-use Slim\Interfaces\CallableResolverInterface;
+use Invoker\Exception\NotCallableException;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Interfaces\AdvancedCallableResolverInterface;
 
 /**
  * Resolve middleware and route callables using PHP-DI.
  */
-class CallableResolver implements CallableResolverInterface
+class CallableResolver implements AdvancedCallableResolverInterface
 {
     /**
      * @var \Invoker\CallableResolver
@@ -18,11 +21,63 @@ class CallableResolver implements CallableResolverInterface
     {
         $this->callableResolver = $callableResolver;
     }
+
     /**
      * {@inheritdoc}
      */
     public function resolve($toResolve): callable
     {
+        $toResolve = $this->translateNotation($toResolve);
+
         return $this->callableResolver->resolve($toResolve);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveRoute($toResolve): callable
+    {
+        $toResolve = $this->translateNotation($toResolve);
+
+        return $this->resolvePossibleSignature($toResolve, 'handle', RequestHandlerInterface::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveMiddleware($toResolve): callable
+    {
+        $toResolve = $this->translateNotation($toResolve);
+
+        return $this->resolvePossibleSignature($toResolve, 'process', MiddlewareInterface::class);
+    }
+
+    /**
+     * Translate Slim string callable notation ('nameOrKey:method') to PHP-DI notation ('nameOrKey::method').
+     */
+    private function translateNotation($toResolve)
+    {
+        if (is_string($toResolve) && preg_match(\Slim\CallableResolver::$callablePattern, $toResolve)) {
+            $toResolve = str_replace(':', '::', $toResolve);
+        }
+
+        return $toResolve;
+    }
+
+    private function resolvePossibleSignature($toResolve, string $method, string $typeName): callable
+    {
+        if (is_string($toResolve)) {
+            try {
+                $callable = $this->resolve([$toResolve, $method]);
+
+                if (is_array($callable) && $callable[0] instanceof $typeName) {
+                    return $callable;
+                }
+            } catch (NotCallableException $e) {
+                // Fall back to looking for a generic callable.
+            }
+        }
+
+        return $this->resolve($toResolve);
     }
 }

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Bridge\Slim\Test;
+
+use DI\Bridge\Slim\Bridge;
+use DI\Bridge\Slim\Test\Fixture\UserController;
+use DI\Bridge\Slim\Test\Fixture\UserControllerInvokable;
+use DI\Bridge\Slim\Test\Fixture\UserControllerPsr;
+use DI\Bridge\Slim\Test\Fixture\UserMiddlewarePsr;
+use DI\Container;
+use PHPUnit\Framework\TestCase;
+
+use Slim\Interfaces\AdvancedCallableResolverInterface;
+
+use function DI\get;
+
+
+class CallableTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function resolves_callable()
+    {
+        $app      = Bridge::create();
+        $resolver = $app->getCallableResolver();
+
+        /** @var Container $container */
+        $container = $app->getContainer();
+        $container->set('controller.user', get(UserController::class));
+
+        [$object, $method] = $resolver->resolve(UserController::class . ':dashboard');
+        $this->assertInstanceOf(UserController::class, $object);
+        $this->assertEquals('dashboard', $method);
+
+        [$object, $method] = $resolver->resolve('controller.user:dashboard');
+        $this->assertInstanceOf(UserController::class, $object);
+        $this->assertEquals('dashboard', $method);
+
+        [$object, $method] = $resolver->resolve(UserController::class . '::dashboard');
+        $this->assertInstanceOf(UserController::class, $object);
+        $this->assertEquals('dashboard', $method);
+
+        [$object, $method] = $resolver->resolve([UserController::class, 'dashboard']);
+        $this->assertInstanceOf(UserController::class, $object);
+        $this->assertEquals('dashboard', $method);
+
+        $resolved = $resolver->resolve(UserControllerInvokable::class);
+        $this->assertInstanceOf(UserControllerInvokable::class, $resolved);
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_route()
+    {
+        $app = Bridge::create();
+        /** @var AdvancedCallableResolverInterface $resolver */
+        $resolver = $app->getCallableResolver();
+
+        /** @var Container $container */
+        $container = $app->getContainer();
+        $container->set('controller.userpsr', get(UserControllerPsr::class));
+
+        [$object, $method] = $resolver->resolveRoute(UserControllerPsr::class);
+        $this->assertInstanceOf(UserControllerPsr::class, $object);
+        $this->assertEquals('handle', $method);
+
+        [$object, $method] = $resolver->resolveRoute('controller.userpsr');
+        $this->assertInstanceOf(UserControllerPsr::class, $object);
+        $this->assertEquals('handle', $method);
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_middleware()
+    {
+        $app      = Bridge::create();
+        /** @var AdvancedCallableResolverInterface $resolver */
+        $resolver = $app->getCallableResolver();
+
+        [$object, $method] = $resolver->resolveMiddleware(UserMiddlewarePsr::class);
+        $this->assertInstanceOf(UserMiddlewarePsr::class, $object);
+        $this->assertEquals('process', $method);
+    }
+}

--- a/tests/Fixture/UserControllerInvokable.php
+++ b/tests/Fixture/UserControllerInvokable.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace DI\Bridge\Slim\Test\Fixture;
+
+use Psr\Http\Message\ResponseInterface;
+
+class UserControllerInvokable
+{
+    public function __invoke(ResponseInterface $response)
+    {
+        $response->getBody()->write('Hello world!');
+
+        return $response;
+    }
+}

--- a/tests/Fixture/UserControllerPsr.php
+++ b/tests/Fixture/UserControllerPsr.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace DI\Bridge\Slim\Test\Fixture;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class UserControllerPsr implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new TextResponse('Hello world!');
+    }
+}

--- a/tests/Fixture/UserMiddlewarePsr.php
+++ b/tests/Fixture/UserMiddlewarePsr.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Bridge\Slim\Test\Fixture;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class UserMiddlewarePsr implements MiddlewareInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return new TextResponse('Hello ' . $request->getQueryParams()['foo']);
+    }
+}

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -3,11 +3,12 @@
 namespace DI\Bridge\Slim\Test;
 
 use DI\Bridge\Slim\Bridge;
+use DI\Bridge\Slim\Test\Fixture\UserMiddlewarePsr;
 use DI\Bridge\Slim\Test\Mock\RequestFactory;
+use Laminas\Diactoros\Response\TextResponse;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\TextResponse;
 
 class MiddlewareTest extends TestCase
 {
@@ -20,6 +21,20 @@ class MiddlewareTest extends TestCase
         $app->add(function (ServerRequestInterface $request, RequestHandlerInterface $next) {
             return new TextResponse('Hello ' . $request->getQueryParams()['foo']);
         });
+        $app->get('/', function () {});
+
+        $response = $app->handle(RequestFactory::create('/', 'foo=matt'));
+
+        $this->assertEquals('Hello matt', $response->getBody()->__toString());
+    }
+
+    /**
+     * @test
+     */
+    public function invokes_class_name_middleware()
+    {
+        $app = Bridge::create();
+        $app->add(UserMiddlewarePsr::class);
         $app->get('/', function () {});
 
         $response = $app->handle(RequestFactory::create('/', 'foo=matt'));


### PR DESCRIPTION
1. Adds support for Slim callable notation with single colon (`name:method`).
2. Enables resolving PSR objects, so that addressing them by class name isn't broken.

Fixes #51

Alternative to #70, I tried to not change constructor signature. Since interface extends the previously used one, backwards compatibility should be intact.

One implementation difference with upstream is that resolver there depends directly on container and can do container lookups. I would prefer to do that, but backwards compatibility issue, same as above.

Related disparity with Slim is closure callbacks not binding to container, see #52.

Includes unit tests for everything I could think of, but needs more people to look at. A lot of possible cases between all the syntaxes and contexts.