### PR TITLE
Added 'args' parameter to support route placeholders as an Array type argument in resolved controller from container

### DIFF
--- a/src/ControllerInvoker.php
+++ b/src/ControllerInvoker.php
@@ -38,6 +38,7 @@ class ControllerInvoker implements InvocationStrategyInterface
         $parameters = [
             'request'  => $request,
             'response' => $response,
+            'args'     => $routeArguments,
         ];
         // Inject the route arguments by name
         $parameters += $routeArguments;

--- a/tests/Fixture/UserController.php
+++ b/tests/Fixture/UserController.php
@@ -3,12 +3,28 @@
 namespace DI\Bridge\Slim\Test\Fixture;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class UserController
 {
     public function dashboard(ResponseInterface $response)
     {
         $response->getBody()->write('Hello world!');
+
+        return $response;
+    }
+
+    /**
+     * @param ServerRequestInterface $request PSR-7 request
+     * @param ResponseInterface $response PSR-7 response
+     * @param array $args The route's placeholder arguments
+     *
+     * @return ResponseInterface
+     */
+    public function invite(ServerRequestInterface $request, ResponseInterface $response, array $args)
+    {
+        $str = join(' ', $args);
+        $response->getBody()->write("Hello $str!");
 
         return $response;
     }

--- a/tests/RoutingTest.php
+++ b/tests/RoutingTest.php
@@ -123,4 +123,17 @@ class RoutingTest extends TestCase
         $response = $app->handle(RequestFactory::create());
         $this->assertEquals('Hello world!', (string) $response->getBody());
     }
+
+    /**
+     * @test
+     */
+    public function injects_route_placeholders_array_to_resolved_controller_from_container()
+    {
+        $app = Bridge::create();
+        $app->get('/{prefix}/{name}', [UserController::class, 'invite']);
+
+        $response = $app->handle(RequestFactory::create('/dear/slim'));
+        $this->assertEquals('Hello dear slim!', (string) $response->getBody());
+    }
+
 }


### PR DESCRIPTION
Added 'args' parameter to support route placeholders as an Array type argument in resolved controller from container.
Tests and UserController fixture updated; UserController->invite() shows basic usage where missing **args** caused error.

The 'native' Slim missing **args** argument caused following issues for the given test case fixture method arguments:
1. Not being able to use route arguments as keys of $args Array if route was configured to use callable class name (and method name if used).
2. Error "Unable to invoke the callable because no value was given for parameter 3 ($args)" in Invoker\Exception\NotEnoughParametersException


