### PR TITLE
Reordered $resolvers

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -41,11 +41,11 @@ class Bridge
 
     private static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
     {
-        $resolvers = [
-            // Inject parameters by name first
-            new AssociativeArrayResolver(),
+        $resolvers = [            
             // Then inject services by type-hints for those that weren't resolved
             new TypeHintContainerResolver($container),
+            // Inject parameters by name
+            new AssociativeArrayResolver(),
             // Then fall back on parameters default values for optional route parameters
             new DefaultValueResolver(),
         ];


### PR DESCRIPTION

Now https://github.com/PHP-DI/Slim-Bridge/blob/master/src/Bridge.php#L44
```php
         $resolvers = [
            // Inject parameters by name first
            new AssociativeArrayResolver(),
            // Then inject services by type-hints for those that weren't resolved
            new TypeHintContainerResolver($container),
            // Then fall back on parameters default values for optional route parameters
            new DefaultValueResolver(),
        ];
```

The code

```php
$app->post('/', [MyController::class, 'run'])

final class MyController
{
    public function run(\App\Model\RpcRequest $request): Response
    {
        // ...
    }
}
```

throws
```
TypeError
Argument 1 passed to App\MyController::run() must be an instance of \App\Model\RpcRequest, instance of Slim\Psr7\Request given
```
This looks more like a bug than consistent behavior, even though it has been documented.
It is possible that this will lead to broken backward compatibility :/