### PR TITLE
Improve ease of extention

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -39,7 +39,10 @@ class Bridge
         return $app;
     }
 
-    private static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
+    /**
+     * Create an invoker with the default resolvers.
+     */
+    protected static function createInvoker(ContainerInterface $container): Invoker
     {
         $resolvers = [
             // Inject parameters by name first
@@ -50,8 +53,14 @@ class Bridge
             new DefaultValueResolver,
         ];
 
-        $invoker = new Invoker(new ResolverChain($resolvers), $container);
+        return new Invoker(new ResolverChain($resolvers), $container);
+    }
 
-        return new ControllerInvoker($invoker);
+    /**
+     * Create a controller invoker with the default resolvers.
+     */
+    protected static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
+    {
+        return new ControllerInvoker(self::createInvoker($container));
     }
 }

--- a/src/ControllerInvoker.php
+++ b/src/ControllerInvoker.php
@@ -24,7 +24,6 @@ class ControllerInvoker implements InvocationStrategyInterface
      * @param ServerRequestInterface $request        The request object.
      * @param ResponseInterface      $response       The response object.
      * @param array                  $routeArguments The route's placeholder arguments
-     * @return ResponseInterface|string The response from the callable.
      */
     public function __invoke(
         callable $callable,
@@ -42,10 +41,26 @@ class ControllerInvoker implements InvocationStrategyInterface
         // Inject the attributes defined on the request
         $parameters += $request->getAttributes();
 
-        return $this->invoker->call($callable, $parameters);
+        return $this->processResponse($this->invoker->call($callable, $parameters));
     }
 
-    private static function injectRouteArguments(ServerRequestInterface $request, array $routeArguments): ServerRequestInterface
+    /**
+     * Allow for child classes to process the response.
+     *
+     * @param ResponseInterface|string $response The response from the callable.
+     * @return ResponseInterface|string The processed response
+     */
+    protected function processResponse($response)
+    {
+        return $response;
+    }
+
+    /**
+     * Inject route arguments into the request.
+     *
+     * @param array                  $routeArguments
+     */
+    protected static function injectRouteArguments(ServerRequestInterface $request, array $routeArguments): ServerRequestInterface
     {
         $requestWithArgs = $request;
         foreach ($routeArguments as $key => $value) {


### PR DESCRIPTION
In our usage we need to extend the ControllerInvoker to have responses normalised from a generic Payload into a standard Response.

To make this easier it would be helpful if some private methods were instead protected and the Invoker fetching the default resolver chain were separated out from the creation of the ControllerInvoker.

Fixes #105

You can see our proposed implementation of the ControllerInvoker [here](https://github.com/andrewnicols/moodle/blob/51ca0ff1ddcd62743dff4ba4498122115403b1f2/lib/classes/router/controller_invoker.php). With the proposed patch here, that would be vastly simplified and easier to maintain, something like:
```php
    #[\Override]
    protected function processResponse($response) {
        return \core\di::get(response_handler::class)->standardise_response($response);
    } 
```

Likewise our custom Bridge implementation would be vastly simplified by breaking apart the `Bridge::createControllerInvoker` method from [this](https://github.com/andrewnicols/moodle/blob/51ca0ff1ddcd62743dff4ba4498122115403b1f2/lib/classes/router/bridge.php#L39-L59), to:
```php
class bridge extends \DI\Bridge\Slim\Bridge {
    #[\Override]
    protected static function createControllerInvoker(ContainerInterface $container): ControllerInvoker {
        return new controller_invoker(self::createInvoker($container));
    }
}
```