### PR TITLE
Allow attributes to not override

### DIFF
--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -22,8 +22,10 @@ use Slim\Interfaces\CallableResolverInterface;
  */
 class Bridge
 {
-    public static function create(?ContainerInterface $container = null): App
-    {
+    public static function create(
+        ?ContainerInterface $container = null,
+        bool $prioritiseAttributesOverParams = false
+    ): App {
         $container = $container ?: new Container;
 
         $callableResolver = new InvokerCallableResolver($container);
@@ -33,7 +35,7 @@ class Bridge
 
         $container->set(App::class, $app);
 
-        $controllerInvoker = static::createControllerInvoker($container);
+        $controllerInvoker = static::createControllerInvoker($container, $prioritiseAttributesOverParams);
         $app->getRouteCollector()->setDefaultInvocationStrategy($controllerInvoker);
 
         return $app;
@@ -59,8 +61,8 @@ class Bridge
     /**
      * Create a controller invoker with the default resolvers.
      */
-    protected static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
+    protected static function createControllerInvoker(ContainerInterface $container, bool $prioritiseAttributesOverParams): ControllerInvoker
     {
-        return new ControllerInvoker(self::createInvoker($container));
+        return new ControllerInvoker(self::createInvoker($container), $prioritiseAttributesOverParams);
     }
 }

--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -39,7 +39,10 @@ class Bridge
         return $app;
     }
 
-    private static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
+    /**
+     * Create an invoker with the default resolvers.
+     */
+    protected static function createInvoker(ContainerInterface $container): Invoker
     {
         $resolvers = [
             // Inject parameters by name first
@@ -50,8 +53,14 @@ class Bridge
             new DefaultValueResolver,
         ];
 
-        $invoker = new Invoker(new ResolverChain($resolvers), $container);
+        return new Invoker(new ResolverChain($resolvers), $container);
+    }
 
-        return new ControllerInvoker($invoker);
+    /**
+     * Create a controller invoker with the default resolvers.
+     */
+    protected static function createControllerInvoker(ContainerInterface $container): ControllerInvoker
+    {
+        return new ControllerInvoker(self::createInvoker($container));
     }
 }

--- a/src/ControllerInvoker.php
+++ b/src/ControllerInvoker.php
@@ -24,7 +24,6 @@ class ControllerInvoker implements InvocationStrategyInterface
      * @param ServerRequestInterface $request        The request object.
      * @param ResponseInterface      $response       The response object.
      * @param array                  $routeArguments The route's placeholder arguments
-     * @return ResponseInterface|string The response from the callable.
      */
     public function __invoke(
         callable $callable,
@@ -42,10 +41,26 @@ class ControllerInvoker implements InvocationStrategyInterface
         // Inject the attributes defined on the request
         $parameters += $request->getAttributes();
 
-        return $this->invoker->call($callable, $parameters);
+        return $this->processResponse($this->invoker->call($callable, $parameters));
     }
 
-    private static function injectRouteArguments(ServerRequestInterface $request, array $routeArguments): ServerRequestInterface
+    /**
+     * Allow for child classes to process the response.
+     *
+     * @param ResponseInterface|string $response The response from the callable.
+     * @return ResponseInterface|string The processed response
+     */
+    protected function processResponse($response)
+    {
+        return $response;
+    }
+
+    /**
+     * Inject route arguments into the request.
+     *
+     * @param array                  $routeArguments
+     */
+    protected static function injectRouteArguments(ServerRequestInterface $request, array $routeArguments): ServerRequestInterface
     {
         $requestWithArgs = $request;
         foreach ($routeArguments as $key => $value) {

--- a/tests/RoutingTest.php
+++ b/tests/RoutingTest.php
@@ -130,6 +130,26 @@ class RoutingTest extends TestCase
     /**
      * @test
      */
+    public function prefers_request_attribute_over_route_placeholder_if_configured()
+    {
+        $app = Bridge::create(null, true);
+        $app->add(function (ServerRequestInterface $request, RequestHandlerInterface $next) {
+            return $next->handle($request->withAttribute('name', 'Bob'));
+        });
+        $app->get('/{name}', function ($name, $request, $response) {
+            $response->getBody()->write('Hello ' . $name . ', from ' . $request->getAttribute('name'));
+            return $response;
+        });
+
+        $response = $app->handle(RequestFactory::create('/matt'));
+
+        // The route placeholder does not override the request attribute but the placeholder is still provided to the controller
+        $this->assertEquals('Hello matt, from Bob', (string) $response->getBody());
+    }
+
+    /**
+     * @test
+     */
     public function resolve_controller_from_container()
     {
         $app = Bridge::create();


### PR DESCRIPTION
Based on #89

This allows for configuration of the placeholder overiding an attribute behaviour as discussed in #86.

If there's a more appropriate way to handle this configuration, I'm happy to change it. I don't find the current approach very elegant but I can't see a better way right now (though it is nearly 1am).

It's worth noting that this change does not change the parameter value to be the attribute, it merely stops the attribute from being overwritten by the placeholder value if a value is already set.